### PR TITLE
fix streams example(6), transfer file instead of directory

### DIFF
--- a/core/client.go
+++ b/core/client.go
@@ -388,3 +388,19 @@ func (c *Client) SetCloseHandler(fn func()) {
 func (c *Client) ClientID() string {
 	return c.clientID
 }
+
+// OpenStream opens a stream.
+func (c *Client) OpenStream(ctx context.Context) (io.ReadWriteCloser, error) {
+	if c.conn == nil {
+		return nil, errors.New("c.conn is nil")
+	}
+	return c.conn.OpenStreamSync(ctx)
+}
+
+// AcceptStream returns the next stream opened by the server, blocking until one is available.
+func (c *Client) AcceptStream(ctx context.Context) (io.ReadWriteCloser, error) {
+	if c.conn == nil {
+		return nil, errors.New("c.conn is nil")
+	}
+	return c.conn.AcceptStream(ctx)
+}

--- a/core/connection.go
+++ b/core/connection.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"sync"
 
+	"github.com/lucas-clemente/quic-go"
 	"github.com/yomorun/yomo/core/frame"
 	"github.com/yomorun/yomo/pkg/logger"
 )
@@ -24,6 +25,8 @@ type Connection interface {
 	Write(f frame.Frame) error
 	// ObserveDataTags observed data tags
 	ObserveDataTags() []byte
+	// QUICConn gets the quic connection.
+	QUICConn() quic.Connection
 }
 
 type connection struct {
@@ -35,9 +38,10 @@ type connection struct {
 	observed   []byte // observed data tags
 	mu         sync.Mutex
 	closed     bool
+	qconn      quic.Connection // quic connection.
 }
 
-func newConnection(name string, clientID string, clientType ClientType, metadata Metadata, stream io.ReadWriteCloser, observed []byte) Connection {
+func newConnection(name string, clientID string, clientType ClientType, metadata Metadata, stream io.ReadWriteCloser, observed []byte, qconn quic.Connection) Connection {
 	return &connection{
 		name:       name,
 		clientID:   clientID,
@@ -46,6 +50,7 @@ func newConnection(name string, clientID string, clientType ClientType, metadata
 		metadata:   metadata,
 		stream:     stream,
 		closed:     false,
+		qconn:      qconn,
 	}
 }
 
@@ -96,4 +101,9 @@ func (c *connection) ObserveDataTags() []byte {
 // ClientID connection client ID
 func (c *connection) ClientID() string {
 	return c.clientID
+}
+
+// QUICConn gets the quic connection.
+func (c *connection) QUICConn() quic.Connection {
+	return c.qconn
 }

--- a/core/frame/frame.go
+++ b/core/frame/frame.go
@@ -24,7 +24,7 @@ const (
 
 	// StreamFrame
 	TagOfStreamFrame    Type = 0x2C
-	TagOfStreamSinkTags Type = 0x01
+	TagOfStreamDataTags Type = 0x01
 	TagOfStreamMetadata Type = 0x02
 
 	TagOfTokenFrame Type = 0x3E

--- a/core/frame/frame.go
+++ b/core/frame/frame.go
@@ -22,6 +22,11 @@ const (
 	TagOfPayloadFrame  Type = 0x2E
 	TagOfBackflowFrame Type = 0x2D
 
+	// StreamFrame
+	TagOfStreamFrame    Type = 0x2C
+	TagOfStreamSinkTags Type = 0x01
+	TagOfStreamMetadata Type = 0x02
+
 	TagOfTokenFrame Type = 0x3E
 	// HandshakeFrame
 	TagOfHandshakeFrame           Type = 0x3D
@@ -85,6 +90,8 @@ func (f Type) String() string {
 		return "HandshakeName"
 	case TagOfHandshakeType:
 		return "HandshakeType"
+	case TagOfStreamFrame:
+		return "StreamFrame"
 	default:
 		return "UnknownFrame"
 	}

--- a/core/frame/stream_frame.go
+++ b/core/frame/stream_frame.go
@@ -1,0 +1,74 @@
+package frame
+
+import "github.com/yomorun/y3"
+
+// StreamFrame is a frame for stream.
+type StreamFrame struct {
+	sinkTags []byte
+	metadata []byte
+}
+
+// NewStreamFrame creates a new StreamFrame.
+func NewStreamFrame(sinkTags []byte) *StreamFrame {
+	return &StreamFrame{
+		sinkTags: sinkTags,
+	}
+}
+
+// Type gets the type of StreamFrame.
+func (f *StreamFrame) Type() Type {
+	return TagOfStreamFrame
+}
+
+// SinkTags gets the sink tags of StreamFrame.
+func (f *StreamFrame) SinkTags() []byte {
+	return f.sinkTags
+}
+
+// Metadata gets the metadata of StreamFrame.
+func (f *StreamFrame) Metadata() []byte {
+	return f.metadata
+}
+
+// SetMetadata sets the metadata of StreamFrame.
+func (f *StreamFrame) SetMetadata(metadata []byte) {
+	f.metadata = metadata
+}
+
+// Encode to Y3 encoded bytes.
+func (f *StreamFrame) Encode() []byte {
+	stream := y3.NewNodePacketEncoder(byte(f.Type()))
+	// sink
+	sinkBlock := y3.NewPrimitivePacketEncoder(byte(TagOfStreamSinkTags))
+	sinkBlock.SetBytesValue(f.sinkTags)
+	stream.AddPrimitivePacket(sinkBlock)
+	// metadata
+	if f.metadata != nil {
+		metaBlock := y3.NewPrimitivePacketEncoder(byte(TagOfStreamMetadata))
+		metaBlock.SetBytesValue(f.metadata)
+		stream.AddPrimitivePacket(metaBlock)
+	}
+
+	return stream.Encode()
+}
+
+// DecodeToStreamFrame decodes Y3 encoded bytes to StreamFrame.
+func DecodeToStreamFrame(buf []byte) (*StreamFrame, error) {
+	nodeBlock := y3.NodePacket{}
+	_, err := y3.DecodeToNodePacket(buf, &nodeBlock)
+	if err != nil {
+		return nil, err
+	}
+	stream := &StreamFrame{}
+	for k, v := range nodeBlock.PrimitivePackets {
+		switch k {
+		case byte(TagOfStreamSinkTags):
+			stream.sinkTags = v.ToBytes()
+			break
+		case byte(TagOfStreamMetadata):
+			stream.metadata = v.ToBytes()
+			break
+		}
+	}
+	return stream, nil
+}

--- a/core/frame/stream_frame.go
+++ b/core/frame/stream_frame.go
@@ -4,14 +4,14 @@ import "github.com/yomorun/y3"
 
 // StreamFrame is a frame for stream.
 type StreamFrame struct {
-	sinkTags []byte
+	dataTags []byte
 	metadata []byte
 }
 
 // NewStreamFrame creates a new StreamFrame.
-func NewStreamFrame(sinkTags []byte) *StreamFrame {
+func NewStreamFrame(dataTags []byte) *StreamFrame {
 	return &StreamFrame{
-		sinkTags: sinkTags,
+		dataTags: dataTags,
 	}
 }
 
@@ -20,9 +20,9 @@ func (f *StreamFrame) Type() Type {
 	return TagOfStreamFrame
 }
 
-// SinkTags gets the sink tags of StreamFrame.
-func (f *StreamFrame) SinkTags() []byte {
-	return f.sinkTags
+// DataTags gets the data tags of StreamFrame.
+func (f *StreamFrame) DataTags() []byte {
+	return f.dataTags
 }
 
 // Metadata gets the metadata of StreamFrame.
@@ -38,10 +38,10 @@ func (f *StreamFrame) SetMetadata(metadata []byte) {
 // Encode to Y3 encoded bytes.
 func (f *StreamFrame) Encode() []byte {
 	stream := y3.NewNodePacketEncoder(byte(f.Type()))
-	// sink
-	sinkBlock := y3.NewPrimitivePacketEncoder(byte(TagOfStreamSinkTags))
-	sinkBlock.SetBytesValue(f.sinkTags)
-	stream.AddPrimitivePacket(sinkBlock)
+	// tags
+	tagsBlock := y3.NewPrimitivePacketEncoder(byte(TagOfStreamDataTags))
+	tagsBlock.SetBytesValue(f.dataTags)
+	stream.AddPrimitivePacket(tagsBlock)
 	// metadata
 	if f.metadata != nil {
 		metaBlock := y3.NewPrimitivePacketEncoder(byte(TagOfStreamMetadata))
@@ -62,8 +62,8 @@ func DecodeToStreamFrame(buf []byte) (*StreamFrame, error) {
 	stream := &StreamFrame{}
 	for k, v := range nodeBlock.PrimitivePackets {
 		switch k {
-		case byte(TagOfStreamSinkTags):
-			stream.sinkTags = v.ToBytes()
+		case byte(TagOfStreamDataTags):
+			stream.dataTags = v.ToBytes()
 			break
 		case byte(TagOfStreamMetadata):
 			stream.metadata = v.ToBytes()

--- a/core/handler_type.go
+++ b/core/handler_type.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"io"
+
 	"github.com/yomorun/yomo/core/frame"
 )
 
@@ -9,3 +11,6 @@ type AsyncHandler func([]byte) (byte, []byte)
 
 // PipeHandler is the bidirectional stream mode (blocking).
 type PipeHandler func(in <-chan []byte, out chan<- *frame.PayloadFrame)
+
+// StreamHandler is the multiple stream mode.
+type StreamHandler func(in io.Reader) io.Reader

--- a/core/server.go
+++ b/core/server.go
@@ -491,7 +491,6 @@ func (s *Server) handleStreamFrame(c *Context) error {
 		return fmt.Errorf("handleStreamFrame connector cannot find %s", fromID)
 	}
 
-	f := c.Frame.(*frame.StreamFrame)
 	// route
 	route := s.router.Route(from.Metadata())
 	if route == nil {
@@ -500,6 +499,7 @@ func (s *Server) handleStreamFrame(c *Context) error {
 	}
 
 	// get sfn connection ids from route
+	f := c.Frame.(*frame.StreamFrame)
 	dataTags := f.DataTags()
 	sfnConnIDs := []string{}
 	for _, tag := range dataTags {

--- a/core/stream_parser.go
+++ b/core/stream_parser.go
@@ -39,6 +39,8 @@ func ParseFrame(stream io.Reader) (frame.Frame, error) {
 		return frame.DecodeToGoawayFrame(buf)
 	case 0x80 | byte(frame.TagOfBackflowFrame):
 		return frame.DecodeToBackflowFrame(buf)
+	case 0x80 | byte(frame.TagOfStreamFrame):
+		return frame.DecodeToStreamFrame(buf)
 	default:
 		return nil, fmt.Errorf("unknown frame type, buf[0]=%#x", buf[0])
 	}

--- a/core/yerr/errors.go
+++ b/core/yerr/errors.go
@@ -54,6 +54,8 @@ const (
 	ErrorCodeAfterHandler ErrorCode = 0xC4
 	// ErrorCodeHandshake handshake frame
 	ErrorCodeHandshake ErrorCode = 0xC5
+	// ErrorCodeStreamHandler stream handler
+	ErrorCodeStreamHandler ErrorCode = 0xC6
 	// ErrorCodeRejected server rejected
 	ErrorCodeRejected ErrorCode = 0xCC
 	// ErrorCodeGoaway goaway frame

--- a/example/5-backflow/README.md
+++ b/example/5-backflow/README.md
@@ -76,7 +76,7 @@ go run ./source/main.go
 
 ### Results
 
-The terminal of `yomo-srouce` will print the real-time receives value.
+The terminal of `yomo-source` will print the real-time receives value.
 
 ```bash
 2022-06-13 16:06:48.690 [source] ✅ Emit 158.30 to YoMo-Zipper

--- a/example/6-multi-stream/README.md
+++ b/example/6-multi-stream/README.md
@@ -66,7 +66,7 @@ go run main.go /path/to/dir
 
 ### Results
 
-The terminal of `yomo-srouce` will print the real-time receives value.
+The terminal of `yomo-source` will print the file size and md5.
 
 ```bash
 
@@ -78,7 +78,7 @@ The terminal of `yomo-srouce` will print the real-time receives value.
 2022-09-07 15:31:09.027	file: test2.mp4, md5: 372148e7d1ba577914047a1ec4580dc9
 ```
 
-The terminal of `sfn-1` will print the real-time noise value.
+The terminal of `sfn-1` will print the receiving file's size and md5.
 
 ```bash
 2022-09-07 15:30:47.819	receiving file: test1.mp4
@@ -89,7 +89,7 @@ The terminal of `sfn-1` will print the real-time noise value.
 2022-09-07 15:31:09.062	file: test2.mp4, md5: 372148e7d1ba577914047a1ec4580dc9
 ```
 
-The terminal of `sfn-2` will print the real-time noise value.
+The terminal of `sfn-2` will will print the receiving file's size and md5.
 
 ```bash
 2022-09-07 15:30:47.820	receiving file: test1.mp4

--- a/example/6-multi-stream/README.md
+++ b/example/6-multi-stream/README.md
@@ -1,0 +1,102 @@
+# Multiple streams example
+
+This example represents how [source](https://docs.yomo.run/source) pipe the local file stream to [zipper](https://docs.yomo.run/zipper), and then zipper pipe the stream to multiple [stream functions](https://docs.yomo.run/stream-fn).
+
+## Code structure
+
++ `source`: Read the files in a local directory, create a new QUIC stream to pipe the file stream. [docs.yomo.run/source](https://docs.yomo.run/source)
++ `zipper`: Receive the data from `source`, and pipe the stream to `stream-fn` [docs.yomo.run/zipper](https://docs.yomo.run/zipper)
++ `sfn`: Receive the data from `zipper` and store the file in local via `io.copy`. [docs.yomo.run/stream-function](https://docs.yomo.run/stream-fn)
+
+## Prepare
+
+Install YoMo CLI
+
+### Binary (Recommended)
+
+```bash
+$ curl -fsSL "https://bina.egoist.sh/yomorun/cli?name=yomo" | sh
+
+  ==> Resolved version latest to v1.2.1
+  ==> Downloading asset for darwin amd64
+  ==> Installing yomo to /usr/local/bin
+  ==> Installation complete
+```
+
+## Run
+
+### Run [zipper](https://docs.yomo.run/zipper)
+
+```bash
+cd ./zipper
+go run main.go
+
+2022-09-07 15:28:18.324	[yomo:zipper] Listening SIGUSR1, SIGUSR2, SIGTERM/SIGINT...
+2022-09-07 15:28:18.328	[core:server] ✅ [Zipper][17916] Listening on: 127.0.0.1:9000, MODE: DEVELOPMENT, QUIC: [v1 draft-29], AUTH: [none]
+```
+
+### Run [sfn-1](https://docs.yomo.run/stream-fn)
+
+```bash
+cd ./sfn
+go run main.go sink-1
+
+2022-09-07 15:29:17.626	[core:client] use credential: [none]
+2022-09-07 15:29:17.632	[core:client] ❤️  [sink-1][jabXFp5WpHDin5o-mYaId]([::]:61242) is connected to YoMo-Zipper localhost:9000
+```
+
+### Run [sfn-2](https://docs.yomo.run/stream-fn)
+```bash
+cd ./sfn
+go run main.go sink-2
+
+2022-09-07 15:29:51.884	[core:client] use credential: [none]
+2022-09-07 15:29:51.890	[core:client] ❤️  [sink-2][aJb-JKHYYytNq_V2JEJbF]([::]:62413) is connected to YoMo-Zipper localhost:9000
+```
+
+### Run [yomo-source](https://docs.yomo.run/source)
+
+```bash
+cd ./source
+go run main.go /path/to/dir
+
+2022-09-07 15:30:46.810	[core:client] use credential: [none]
+2022-09-07 15:30:46.815	[core:client] ❤️  [source][nrxQzDFtSAr6a5oPJRCSk]([::]:58333) is connected to YoMo-Zipper localhost:9000
+```
+
+### Results
+
+The terminal of `yomo-srouce` will print the real-time receives value.
+
+```bash
+
+2022-09-07 15:30:47.817	sending file test1.mp4 to yomo-zipper...
+2022-09-07 15:30:47.817	sending file test2.mp4 to yomo-zipper...
+2022-09-07 15:31:07.196	file: test1.mp4, written: 366676386
+2022-09-07 15:31:07.196	file: test1.mp4, md5: a6a87007a45e7d35846adb11c118ee1d
+2022-09-07 15:31:09.027	file: test2.mp4, written: 434894207
+2022-09-07 15:31:09.027	file: test2.mp4, md5: 372148e7d1ba577914047a1ec4580dc9
+```
+
+The terminal of `sfn-1` will print the real-time noise value.
+
+```bash
+2022-09-07 15:30:47.819	receiving file: test1.mp4
+2022-09-07 15:30:47.819	receiving file: test2.mp4
+2022-09-07 15:31:07.218	written: 366676386, /path/to/dir/sink-1-test1.mp4
+2022-09-07 15:31:07.218	file: test1.mp4, md5: a6a87007a45e7d35846adb11c118ee1d
+2022-09-07 15:31:09.062	written: 434894207, /path/to/dir/sink-1-test2.mp4
+2022-09-07 15:31:09.062	file: test2.mp4, md5: 372148e7d1ba577914047a1ec4580dc9
+...
+```
+
+The terminal of `sfn-2` will print the real-time noise value.
+
+```bash
+2022-09-07 15:30:47.820	receiving file: test1.mp4
+2022-09-07 15:30:47.820	receiving file: test2.mp4
+2022-09-07 15:31:07.218	written: 366676386, /path/to/dir/sink-2-test1.mp4
+2022-09-07 15:31:07.218	file: test1.mp4, md5: a6a87007a45e7d35846adb11c118ee1d
+2022-09-07 15:31:09.062	written: 434894207, /path/to/dir/sink-2-test2.mp4
+2022-09-07 15:31:09.062	file: test2.mp4, md5: 372148e7d1ba577914047a1ec4580dc9
+```

--- a/example/6-multi-stream/README.md
+++ b/example/6-multi-stream/README.md
@@ -1,12 +1,12 @@
 # Multiple streams example
 
-This example represents how [source](https://docs.yomo.run/source) pipe the local file stream to [zipper](https://docs.yomo.run/zipper), and then zipper pipe the stream to multiple [stream functions](https://docs.yomo.run/stream-fn).
+This example represents how [source](https://docs.yomo.run/source) pipe the local file stream to [zipper](https://docs.yomo.run/zipper), and zipper pipe the stream to multiple [stream functions](https://docs.yomo.run/stream-fn).
 
 ## Code structure
 
-+ `source`: Read the files in a local directory, create a new QUIC stream to pipe the file stream. [docs.yomo.run/source](https://docs.yomo.run/source)
-+ `zipper`: Receive the data from `source`, and pipe the stream to `stream-fn` [docs.yomo.run/zipper](https://docs.yomo.run/zipper)
-+ `sfn`: Receive the data from `zipper` and store the file in local via `io.copy`. [docs.yomo.run/stream-function](https://docs.yomo.run/stream-fn)
++ `source`: Read the files in a local directory, create a new QUIC stream for each file to pipe the file stream. [docs.yomo.run/source](https://docs.yomo.run/source)
++ `zipper`: Receive the data from `source`, create a new stream and pipe the `source` stream to `stream-fn` [docs.yomo.run/zipper](https://docs.yomo.run/zipper)
++ `sfn`: Receive the stream from `zipper` and store the file in local via `io.copy`. [docs.yomo.run/stream-function](https://docs.yomo.run/stream-fn)
 
 ## Prepare
 
@@ -87,7 +87,6 @@ The terminal of `sfn-1` will print the real-time noise value.
 2022-09-07 15:31:07.218	file: test1.mp4, md5: a6a87007a45e7d35846adb11c118ee1d
 2022-09-07 15:31:09.062	written: 434894207, /path/to/dir/sink-1-test2.mp4
 2022-09-07 15:31:09.062	file: test2.mp4, md5: 372148e7d1ba577914047a1ec4580dc9
-...
 ```
 
 The terminal of `sfn-2` will print the real-time noise value.

--- a/example/6-multi-stream/README.md
+++ b/example/6-multi-stream/README.md
@@ -58,7 +58,7 @@ go run main.go sink-2
 
 ```bash
 cd ./source
-go run main.go /path/to/dir
+go run main.go /path/to/file
 
 2022-09-07 15:30:46.810	[core:client] use credential: [none]
 2022-09-07 15:30:46.815	[core:client] ❤️  [source][nrxQzDFtSAr6a5oPJRCSk]([::]:58333) is connected to YoMo-Zipper localhost:9000

--- a/example/6-multi-stream/sink/main.go
+++ b/example/6-multi-stream/sink/main.go
@@ -23,7 +23,7 @@ func main() {
 	if sfnName == "" {
 		sfnName = "sink-1"
 	}
-	// init yomo-source
+	// init yomo-sfn
 	client := yomo.NewStreamFunction(
 		sfnName,
 		yomo.WithZipperAddr("localhost:9000"),
@@ -49,6 +49,7 @@ type fileInfo struct {
 }
 
 func streamHandler(in io.Reader) io.Reader {
+	// get stream frame
 	streamFrame, err := core.ParseFrame(in)
 	if err != nil {
 		log.Println("read frame error:", err)
@@ -59,6 +60,7 @@ func streamHandler(in io.Reader) io.Reader {
 		return nil
 	}
 
+	// get file info from stream frame
 	var info fileInfo
 	err = json.Unmarshal(streamFrame.(*frame.StreamFrame).Metadata(), &info)
 	if err != nil {
@@ -89,7 +91,7 @@ func streamHandler(in io.Reader) io.Reader {
 	return nil
 }
 
-// calu;ateMD5 calculates the md5 of the file.
+// calculateMD5 calculates the md5 of the file.
 func calculateMD5(reader io.Reader, fileName string) {
 	h := md5.New()
 	if _, err := io.Copy(h, reader); err != nil {

--- a/example/6-multi-stream/sink/main.go
+++ b/example/6-multi-stream/sink/main.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"path"
+
+	"github.com/yomorun/yomo"
+	"github.com/yomorun/yomo/core"
+	"github.com/yomorun/yomo/core/frame"
+)
+
+var sfnName string
+
+func main() {
+	if len(os.Args) < 2 {
+		panic("please set the sfn name in args, f.e. go run main.go sfn-1")
+	}
+	sfnName = os.Args[1]
+	if sfnName == "" {
+		sfnName = "sink-1"
+	}
+	// init yomo-source
+	client := yomo.NewStreamFunction(
+		sfnName,
+		yomo.WithZipperAddr("localhost:9000"),
+		yomo.WithObserveDataTags(0x11),
+	)
+	defer client.Close()
+
+	// set stream handler (must set before connect)
+	client.SetStreamHandler(streamHandler)
+
+	// connect to yomo-zipper
+	err := client.Connect()
+	if err != nil {
+		panic(err)
+	}
+
+	select {}
+}
+
+type fileInfo struct {
+	Name string `json:"name"`
+	Dir  string `json:"dir"`
+}
+
+func streamHandler(in io.Reader) io.Reader {
+	streamFrame, err := core.ParseFrame(in)
+	if err != nil {
+		log.Println("read frame error:", err)
+		return nil
+	}
+	if streamFrame.Type() != frame.TagOfStreamFrame {
+		log.Println("the frame type is not TagOfStreamFrame")
+		return nil
+	}
+
+	var info fileInfo
+	err = json.Unmarshal(streamFrame.(*frame.StreamFrame).Metadata(), &info)
+	if err != nil {
+		log.Println("unmarshal the metadata in stream frame error:", err)
+		return nil
+	}
+
+	log.Println("receiving file:", info.Name)
+
+	// calculate the md5 of the file
+	pipeReader, pipeWriter := io.Pipe()
+
+	go calculateMD5(pipeReader, info.Name)
+
+	// create output file
+	p := path.Join(info.Dir, sfnName+"-"+info.Name)
+	f, err := os.Create(p)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	written, err := io.Copy(io.MultiWriter(pipeWriter, f), in)
+	if err != nil && err != io.EOF {
+		panic(err)
+	}
+	pipeWriter.Close()
+	log.Printf("written: %d, %s\n", written, p)
+	return nil
+}
+
+// calu;ateMD5 calculates the md5 of the file.
+func calculateMD5(reader io.Reader, fileName string) {
+	h := md5.New()
+	if _, err := io.Copy(h, reader); err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("file: %s, md5: %x\n", fileName, h.Sum(nil))
+}

--- a/example/6-multi-stream/source/main.go
+++ b/example/6-multi-stream/source/main.go
@@ -42,7 +42,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	// PROBLEM: how to wait for connection established?
+	// PROBLEM: how to wait util the connection is established?
 	time.Sleep(time.Second)
 
 	// open files in dir

--- a/example/6-multi-stream/source/main.go
+++ b/example/6-multi-stream/source/main.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"time"
+
+	"github.com/yomorun/yomo"
+	"github.com/yomorun/yomo/core/frame"
+)
+
+type fileInfo struct {
+	Name string `json:"name"`
+	Dir  string `json:"dir"`
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		panic("please set the dir in args, f.e. go run main.go /path/to/dir")
+	}
+	dir := os.Args[1]
+	if dir == "" {
+		panic("dir is empty")
+	}
+
+	// init yomo-source
+	client := yomo.NewSource(
+		"source",
+		yomo.WithZipperAddr("localhost:9000"),
+		yomo.WithObserveDataTags(0x10),
+	)
+	defer client.Close()
+
+	// connect to yomo-zipper
+	err := client.Connect()
+	if err != nil {
+		panic(err)
+	}
+	// PROBLEM: how to wait for connection established?
+	time.Sleep(time.Second)
+
+	// open files in dir
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, file := range files {
+		go func(fileName string) {
+			sendFile(client, dir, fileName)
+		}(file.Name())
+	}
+
+	select {}
+}
+
+// sendFile sends the file to yomo-zipper.
+func sendFile(client yomo.Source, dir string, fileName string) {
+	log.Printf("sending file %s to yomo-zipper...", fileName)
+	videoStream, err := os.Open(path.Join(dir, fileName))
+	if err != nil {
+		panic(err)
+	}
+
+	// open a new stream
+	ctx := context.Background()
+	writer, err := client.OpenStream(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	// send a stream frame with file name
+	f := frame.NewStreamFrame([]byte{0x11})
+	info := fileInfo{
+		Name: fileName,
+		Dir:  dir,
+	}
+	meta, _ := json.Marshal(info)
+	f.SetMetadata(meta)
+	_, err = writer.Write(f.Encode())
+	if err != nil {
+		panic(err)
+	}
+
+	// calculate the md5 of the file
+	pipeReader, pipeWriter := io.Pipe()
+	go calculateMD5(pipeReader, fileName)
+
+	// send video stream to yomo-zipper
+	written, err := io.Copy(io.MultiWriter(pipeWriter, writer), videoStream)
+	if err != nil && err != io.EOF {
+		panic(err)
+	}
+	log.Printf("file: %s, written: %d\n", fileName, written)
+	writer.Close()
+	pipeWriter.Close()
+	videoStream.Close()
+}
+
+// calculateMD5 calculates the md5 of the file.
+func calculateMD5(reader io.Reader, fileName string) {
+	h := md5.New()
+	if _, err := io.Copy(h, reader); err != nil {
+		if err != io.EOF {
+			log.Fatal(err)
+		}
+	}
+
+	log.Printf("file: %s, md5: %x\n", fileName, h.Sum(nil))
+}

--- a/example/6-multi-stream/zipper/main.go
+++ b/example/6-multi-stream/zipper/main.go
@@ -8,7 +8,7 @@ func main() {
 	// zipper initialize
 	zipper := yomo.NewZipperWithOptions(
 		"Zipper",
-		yomo.WithZipperAddr("localhost:9000"),
+		yomo.WithZipperAddr("0.0.0.0:9000"),
 	)
 	defer zipper.Close()
 	// configurate zipper workflow

--- a/example/6-multi-stream/zipper/main.go
+++ b/example/6-multi-stream/zipper/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/yomorun/yomo"
+)
+
+func main() {
+	// zipper initialize
+	zipper := yomo.NewZipperWithOptions(
+		"Zipper",
+		yomo.WithZipperAddr("localhost:9000"),
+	)
+	defer zipper.Close()
+	// configurate zipper workflow
+	zipper.ConfigWorkflow("./workflow.yaml")
+	// zipper serve
+	err := zipper.ListenAndServe()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/example/6-multi-stream/zipper/workflow.yaml
+++ b/example/6-multi-stream/zipper/workflow.yaml
@@ -2,6 +2,5 @@ name: Service
 host: localhost
 port: 9000
 functions:
-  - name: source
   - name: sink-1
   - name: sink-2

--- a/example/6-multi-stream/zipper/workflow.yaml
+++ b/example/6-multi-stream/zipper/workflow.yaml
@@ -1,0 +1,7 @@
+name: Service
+host: localhost
+port: 9000
+functions:
+  - name: source
+  - name: sink-1
+  - name: sink-2

--- a/source.go
+++ b/source.go
@@ -2,6 +2,7 @@ package yomo
 
 import (
 	"context"
+	"io"
 
 	"github.com/yomorun/yomo/core"
 	"github.com/yomorun/yomo/core/frame"
@@ -29,6 +30,8 @@ type Source interface {
 	SetReceiveHandler(fn func(tag byte, data []byte))
 	// Write the data to all downstream
 	Broadcast(data []byte) error
+	// OpenStream will open a QUIC stream.
+	OpenStream(ctx context.Context) (io.ReadWriteCloser, error)
 }
 
 // YoMo-Source
@@ -124,4 +127,9 @@ func (s *yomoSource) Broadcast(data []byte) error {
 	s.client.Logger().Debugf("%sBroadcast: tid=%s, source_id=%s, data[%d]=%# x",
 		sourceLogPrefix, f.TransactionID(), f.SourceID(), len(data), frame.Shortly(data))
 	return s.client.WriteFrame(f)
+}
+
+// OpenStream will open a QUIC stream.
+func (s *yomoSource) OpenStream(ctx context.Context) (io.ReadWriteCloser, error) {
+	return s.client.OpenStream(ctx)
 }


### PR DESCRIPTION
before, we transfer `dir`, if the target dir has sub-dir, source will crash. So I changed to transfer file instead of dir, to avoid this situation.