### PR TITLE
fix streams example(6), transfer file instead of directory

### DIFF
--- a/example/6-multi-stream/README.md
+++ b/example/6-multi-stream/README.md
@@ -58,7 +58,7 @@ go run main.go sink-2
 
 ```bash
 cd ./source
-go run main.go /path/to/dir
+go run main.go /path/to/file
 
 2022-09-07 15:30:46.810	[core:client] use credential: [none]
 2022-09-07 15:30:46.815	[core:client] ❤️  [source][nrxQzDFtSAr6a5oPJRCSk]([::]:58333) is connected to YoMo-Zipper localhost:9000

--- a/example/6-multi-stream/zipper/main.go
+++ b/example/6-multi-stream/zipper/main.go
@@ -8,7 +8,7 @@ func main() {
 	// zipper initialize
 	zipper := yomo.NewZipperWithOptions(
 		"Zipper",
-		yomo.WithZipperAddr("localhost:9000"),
+		yomo.WithZipperAddr("0.0.0.0:9000"),
 	)
 	defer zipper.Close()
 	// configurate zipper workflow


### PR DESCRIPTION
before, we transfer `dir`, if the target dir has sub-dir, source will crash. So I changed to transfer file instead of dir, to avoid this situation.